### PR TITLE
fix 82 and 11 case on pl

### DIFF
--- a/jobs/Tests/Physical_Lights/test_cases.json
+++ b/jobs/Tests/Physical_Lights/test_cases.json
@@ -244,7 +244,7 @@
             "cmds.setAttr('RPRPhysicalLight1Shape.lightType', 1)",
             "cmds.setAttr('RPRPhysicalLight1Shape.spotLightInnerConeAngle', 0)",
             "cmds.setAttr('RPRPhysicalLight1Shape.spotLightOuterConeFalloff', 0)",
-            "cmds.setAttr('RPRPhysicalLight1Shape.luminousEfficacy', 0.1)",
+            "cmds.setAttr('RPRPhysicalLight1Shape.luminousEfficacy', 0.1001)",
             "cmds.setAttr('RPRPhysicalLight1Shape.intensity', 0)",
             "rpr_render(case)",
             "resetAttributes()"
@@ -1574,6 +1574,7 @@
         "case": "MAYA_L_PL_082",
         "status": "skipped",
         "functions": [
+            "rpr_render(case)"
         ],
         "script_info": [
             "Create a Cube object",


### PR DESCRIPTION
# Error: line 1: IndexError: file C:\JN\WS\RadeonProRenderMayaPlugin_Test\Work\Results\Maya\Physical_Lights\base_functions.py line 177: list index out of range # 
Error "setAttr: Cannot set the attribute 'RPRPhysicalLight1Shape.luminousEfficacy' below its minimum value of 0.1.