### PR TITLE
New aov case

### DIFF
--- a/jobs/Tests/AOV/test_cases.json
+++ b/jobs/Tests/AOV/test_cases.json
@@ -323,5 +323,19 @@
             "cmds.setAttr('RadeonProRenderGlobals.aovDisplayedInRenderView', 28)",
             "rpr_render(case)"
         ]
+    },
+    {
+        "case": "MAYA_RS_AOV_024",
+        "status": "skipped",
+        "script_info": [
+            "AOV: Reflection Catcher"
+        ],
+        "scene": "AOVConstruct.ma",
+        "functions": [
+            "resetAttributes()",
+            "cmds.setAttr('RadeonProRenderGlobals.aovDisplayedInRenderView', 30)",
+            "cmds.setAttr('RadeonProRenderGlobals.aovReflectionCatcher', 1)",
+            "rpr_render(case)"
+        ]
     }
 ]

--- a/jobs/Tests/AOV/test_cases.json
+++ b/jobs/Tests/AOV/test_cases.json
@@ -326,7 +326,7 @@
     },
     {
         "case": "MAYA_RS_AOV_024",
-        "status": "skipped",
+        "status": "active",
         "script_info": [
             "AOV: Reflection Catcher"
         ],


### PR DESCRIPTION
This branch adds test case MAYA_RS_AOV_024 to autotests (reflection catcher AOV check)
https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderMayaPluginManual/2490/Test_20Report/