### PR TITLE
Added cases to animation and motion blur

### DIFF
--- a/jobs/Tests/Animation/test_cases.json
+++ b/jobs/Tests/Animation/test_cases.json
@@ -405,5 +405,41 @@
             "time.sleep(5)",
             "rpr_render(case)"
         ]
+    },
+    {
+        "case": "MAYA_RS_AN_032",
+        "status": "active",
+        "script_info": [
+            "Frame - 10"
+        ],
+        "scene": "Mocap.ma", 
+        "functions": [
+            "cmds.currentTime(10)",
+            "rpr_render(case)"
+        ]
+    },
+    {
+        "case": "MAYA_RS_AN_033",
+        "status": "active",
+        "script_info": [
+            "Frame - 30"
+        ],
+        "scene": "Mocap.ma", 
+        "functions": [
+            "cmds.currentTime(30)",
+            "rpr_render(case)"
+        ]
+    },
+    {
+        "case": "MAYA_RS_AN_034",
+        "status": "active",
+        "script_info": [
+            "Frame - 60"
+        ],
+        "scene": "Mocap.ma", 
+        "functions": [
+            "cmds.currentTime(60)",
+            "rpr_render(case)"
+        ]
     }
 ]

--- a/jobs/Tests/Motion_Blur/test_cases.json
+++ b/jobs/Tests/Motion_Blur/test_cases.json
@@ -313,5 +313,36 @@
             "cmds.setAttr('RadeonProRenderGlobals.motionBlurScale', 100.0)",
             "rpr_render(case)"
         ]
+    },
+    {
+        "case": "MAYA_RS_MB_019",
+        "status": "active",
+        "script_info": [
+            "Camera Motion blur"
+        ],
+        "scene": "CameraMotion.ma",
+        "functions": [
+            "cmds.currentTime(60)",
+            "cmds.setAttr('RadeonProRenderGlobals.motionBlur', 1)",
+            "cmds.setAttr('RadeonProRenderGlobals.motionBlurCameraExposure', 0.375)",
+            "rpr_render(case)",
+            "cmds.setAttr('RadeonProRenderGlobals.motionBlur', 0)"
+        ]
+    },
+    {
+        "case": "MAYA_RS_MB_020",
+        "status": "active",
+        "script_info": [
+            "Motion blur object override"
+        ],
+        "scene": "MotionBlurOverride.ma",
+        "functions": [
+            "cmds.setAttr('RadeonProRenderGlobals.completionCriteriaIterations', 100)",
+            "cmds.currentTime(60)",
+            "cmds.setAttr('RadeonProRenderGlobals.motionBlur', 1)",
+            "cmds.setAttr('RadeonProRenderGlobals.motionBlurCameraExposure', 0.375)",
+            "rpr_render(case)",
+            "cmds.setAttr('RadeonProRenderGlobals.motionBlur', 0)"
+        ]
     }
 ]


### PR DESCRIPTION
This commit adds new test cases for animation and motion blur groups
See motion blur:
https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderMayaPluginManual/2533/Test_20Report/
See animation:
https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderMayaPluginManual/2534/Test_20Report/
