### PR TITLE
Hybrid 020, 025 skipped on 5700

### DIFF
--- a/jobs/Tests/Hybrid_Rendering/test_cases.json
+++ b/jobs/Tests/Hybrid_Rendering/test_cases.json
@@ -288,6 +288,9 @@
         "functions": [
             "cmds.setAttr('RadeonProRenderGlobals.renderQualityFinalRender', 2)",
             "rpr_render(case)"
+        ],
+        "skip_on": [
+            ["AMD Radeon RX 5700 XT"]
         ]
     },
     {
@@ -359,6 +362,9 @@
             "applyMaterial('BasketCaseBlue_Solid')",
             "rpr_render(case)",
             "detachMaterial()"
+        ],
+        "skip_on": [
+            ["AMD Radeon RX 5700 XT"]
         ]
     },
     {


### PR DESCRIPTION
Due to dissappearing faces
https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderMayaPlugin-WeeklyFull/274/Test_20Report/AMD_RX5700XT-Windows-Hybrid_Rendering/Results/Maya/Hybrid_Rendering/report.html