### PR TITLE
Mash 027 skipped on Mac

### DIFF
--- a/jobs/Tests/MASH/test_cases.json
+++ b/jobs/Tests/MASH/test_cases.json
@@ -373,6 +373,9 @@
         "functions": [
             "cmds.currentTime(20)",
             "rpr_render(case)"
+        ],
+        "skip_on": [
+            ["AMD Radeon RX Vega 56 (Metal)"]
         ]
     }
 ]


### PR DESCRIPTION
Skipped due to not loading data using alembic (and sometimes causes crash)