### PR TITLE
Fix args in run.bat

### DIFF
--- a/scripts/run.bat
+++ b/scripts/run.bat
@@ -1,15 +1,15 @@
 set PATH=c:\python35\;c:\python35\scripts\;%PATH%
-set RENDER_DEVICE=%~1
-set FILE_FILTER=%~2
-set TESTS_FILTER="%~3"
-set RX=%~4
-set RY=%~5
-set SPU=%~6
-set ITER=%~7
-set THRESHOLD=%~8
-set TOOL=%~9
+set RENDER_DEVICE=%1
+set FILE_FILTER=%2
+set TESTS_FILTER="%3"
+set RX=%4
+set RY=%5
+set SPU=%6
+set ITER=%7
+set THRESHOLD=%8
+set TOOL=%9
 shift
-set ENGINE=%~9
+set ENGINE=%9
 
 if not defined RX set RX=0
 if not defined RY set RY=0


### PR DESCRIPTION
* PURPOSE
  * Tilda ruins strings by removing extra quotes, so it's broke running several groups in one job
* REPORTS
  * Ruined https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderMayaPluginManual/2867/
  * https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderMayaPluginManual/2888/