### PR TITLE
Refraction glossy fix

### DIFF
--- a/jobs/Tests/Quality/test_cases.json
+++ b/jobs/Tests/Quality/test_cases.json
@@ -114,7 +114,7 @@
         "script_info": [
             "Max Glossy Refraction - 2"
         ],
-        "scene": "Glossy_ray_depth.ma"
+        "scene": "Refraction_ray_depth.ma"
     },
     {
         "case": "MAYA_RS_QL_010",
@@ -127,7 +127,7 @@
         "script_info": [
             "Max Glossy Refraction - 50"
         ],
-        "scene": "Glossy_ray_depth.ma"
+        "scene": "Refraction_ray_depth.ma"
     },
     {
         "case": "MAYA_RS_QL_011",

--- a/jobs/Tests/Quality/test_cases.json
+++ b/jobs/Tests/Quality/test_cases.json
@@ -3,9 +3,9 @@
         "case": "MAYA_RS_QL_001",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.maxRayDepth', 2)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Max Ray Depth - 2"
@@ -16,9 +16,9 @@
         "case": "MAYA_RS_QL_002",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.maxRayDepth', 50)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Max Ray Depth - 50"
@@ -29,9 +29,9 @@
         "case": "MAYA_RS_QL_003",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthDiffuse', 2)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Max Diffuse - 2"
@@ -42,9 +42,9 @@
         "case": "MAYA_RS_QL_004",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthDiffuse', 50)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Max Diffuse - 50"
@@ -55,9 +55,9 @@
         "case": "MAYA_RS_QL_005",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthGlossy', 2)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Max Glossy - 2"
@@ -68,9 +68,9 @@
         "case": "MAYA_RS_QL_006",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthGlossy', 50)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Max Glossy - 50"
@@ -81,9 +81,9 @@
         "case": "MAYA_RS_QL_007",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthRefraction', 2)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Max Refraction - 2"
@@ -94,9 +94,9 @@
         "case": "MAYA_RS_QL_008",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthRefraction', 50)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Max Refraction - 50"
@@ -107,9 +107,9 @@
         "case": "MAYA_RS_QL_009",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthRefractionGlossy', 2)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Max Glossy Refraction - 2"
@@ -120,9 +120,9 @@
         "case": "MAYA_RS_QL_010",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthRefractionGlossy', 50)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Max Glossy Refraction - 50"
@@ -133,9 +133,9 @@
         "case": "MAYA_RS_QL_011",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthShadow', 2)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Max Shadow - 2"
@@ -146,9 +146,9 @@
         "case": "MAYA_RS_QL_012",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthShadow', 50)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Max Shadow - 50"
@@ -159,9 +159,9 @@
         "case": "MAYA_RS_QL_013",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.raycastEpsilon', 0)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Ray Epsilon - 0"
@@ -172,9 +172,9 @@
         "case": "MAYA_RS_QL_014",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.raycastEpsilon', 2)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Ray Epsilon - 2"
@@ -185,9 +185,9 @@
         "case": "MAYA_RS_QL_015",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.enableOOC', 1)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Activate Enable Out of Core Textures checkbox"
@@ -198,10 +198,10 @@
         "case": "MAYA_RS_QL_016",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.enableOOC', 1)",
             "cmds.setAttr('RadeonProRenderGlobals.textureCacheSize', 4096)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Activate Enable Out of Core Textures checkbox",
@@ -213,6 +213,7 @@
         "case": "MAYA_RS_QL_017",
         "status": "skipped",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.maxRayDepth', 2)",
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthDiffuse', 2)",
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthGlossy', 2)",
@@ -220,8 +221,7 @@
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthRefractionGlossy', 2)",
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthShadow', 2)",
             "cmds.setAttr('RadeonProRenderGlobals.raycastEpsilon', 0)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Max Ray Depth - 2",
@@ -238,6 +238,7 @@
         "case": "MAYA_RS_QL_018",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.maxRayDepth', 50)",
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthDiffuse', 50)",
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthGlossy', 50)",
@@ -245,8 +246,7 @@
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthRefractionGlossy', 50)",
             "cmds.setAttr('RadeonProRenderGlobals.maxDepthShadow', 50)",
             "cmds.setAttr('RadeonProRenderGlobals.raycastEpsilon', 2)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Max Ray Depth - 2",
@@ -263,10 +263,10 @@
         "case": "MAYA_RS_QL_019",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.giClampIrradiance', 1)",
             "cmds.setAttr('RadeonProRenderGlobals.giClampIrradianceValue', 50)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Clamp Irradience Value - 50"
@@ -277,10 +277,10 @@
         "case": "MAYA_RS_QL_020",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.giClampIrradiance', 1)",
             "cmds.setAttr('RadeonProRenderGlobals.giClampIrradianceValue', 100)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Clamp Irradience Value - 100"
@@ -291,11 +291,11 @@
         "case": "MAYA_RS_QL_021",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.giClampIrradiance', 1)",
             "cmds.setAttr('RadeonProRenderGlobals.giClampIrradianceValue', 50)",
             "cmds.setAttr('RadeonProRenderGlobals.textureCompression', 1)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Activate Enable Out of Core Textures checkbox",
@@ -307,11 +307,11 @@
         "case": "MAYA_RS_QL_022",
         "status": "active",
         "functions": [
+            "resetAttributes()",
             "cmds.setAttr('RadeonProRenderGlobals.giClampIrradiance', 1)",
             "cmds.setAttr('RadeonProRenderGlobals.giClampIrradianceValue', 100)",
             "cmds.setAttr('RadeonProRenderGlobals.textureCompression', 1)",
-            "rpr_render(case)",
-            "resetAttributes()"
+            "rpr_render(case)"
         ],
         "script_info": [
             "Activate Enable Out of Core Textures checkbox",


### PR DESCRIPTION
- PURPOSE
Fix tests dependancy. Before, attributes were reset after the scene, which means if test is first one to execute it would cause wrong picture. Now all cases have the same starting condition, regardless of execution order
- REPORTS
https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderMayaPluginManual/3063/Test_20Report/