### PR TITLE
Fix detecting of group timeout exceeded case

### DIFF
--- a/jobs/Scripts/base_functions.py
+++ b/jobs/Scripts/base_functions.py
@@ -42,6 +42,7 @@ def reportToJSON(case, render_time=0):
 
     if case['status'] == 'inprogress':
         report['test_status'] = 'passed'
+        report['group_timeout_exceeded'] = False
     else:
         report['test_status'] = case['status']
 
@@ -63,8 +64,6 @@ def reportToJSON(case, render_time=0):
     report['script_info'] = case['script_info']
     report['render_log'] = path.join('render_tool_logs', case['case'] + '.log')
     report['scene_name'] = case.get('scene', '')
-    report['group_timeout_exceeded'] = False
-
     with open(path_to_file, 'w') as file:
         file.write(json.dumps([report], indent=4))
 

--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -276,7 +276,7 @@ def main(args, error_windows):
                 case['status'] = 'active'
                 case['number_of_tries'] = case.get('number_of_tries', 0) + 1
 
-            template = core_config.RENDER_REPORT_BASE
+            template = core_config.RENDER_REPORT_BASE.copy()
             template['test_case'] = case['case']
             template['render_device'] = get_gpu()
             template['test_status'] = 'error'


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1526
### Purpose
* Fix detecting of group timeout exceeded case
### Effect of change
* Mark group_timeout_exceeded param as false for all non-passed and non-skipped cases only after all test runs.
*  Fix incorrect setting of group_timeout_exceeded param if there are skipped cases before active cases.
### :octocat: Related PR'S
* jobs_test_blender: https://github.com/luxteam/jobs_test_blender/pull/114
* jobs_test_max: https://github.com/luxteam/jobs_test_max/pull/44
### Jenkins Builds
* Common build: https://rpr.cis.luxoft.com/job/RadeonProRenderMayaPluginManual/3688/