### PR TITLE
Delete depedence on test group in building of path to baselines

### DIFF
--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -269,13 +269,13 @@ def main(args, error_windows):
     system_pl = platform.system()
 
     baseline_dir = 'rpr_maya_autotests_baselines'
-    if args.engine == 'Northstar' and not 'NorthStar' in args.testType:
+    if args.engine == 'Northstar':
         baseline_dir = baseline_dir + '-NorthStar'
-    elif args.engine == 'Hybrid_Low' and not 'Hybrid' in args.testType:
+    elif args.engine == 'Hybrid_Low':
         baseline_dir = baseline_dir + '-HybridLow'
-    elif args.engine == 'Hybrid_Medium' and not 'Hybrid' in args.testType:
+    elif args.engine == 'Hybrid_Medium':
         baseline_dir = baseline_dir + '-HybridMedium'
-    elif args.engine == 'Hybrid_High' and not 'Hybrid' in args.testType:
+    elif args.engine == 'Hybrid_High':
         baseline_dir = baseline_dir + '-HybridHigh'
 
     if system_pl == "Windows":


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1625
### Purpose
* Delete depedence on test group in building of path to baselines
### Effect of change
* Make logic of building of path to baselines in pipelines and simpleRender scripts same (make it depended only on engine name)
### :octocat: Related PR'S
* jobs_test_blender: https://github.com/luxteam/jobs_test_blender/pull/129
### Jenkins Builds
* https://rpr.cis.luxoft.com/job/RadeonProRenderMayaPluginManual/3778/