### PR TITLE
Marking expected black images for RPRMayaPlugin

### DIFF
--- a/jobs/Tests/AOV/test_cases.json
+++ b/jobs/Tests/AOV/test_cases.json
@@ -145,7 +145,7 @@
         "case": "MAYA_RS_AOV_011",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "AOV: Emission"
         ],
         "scene": "AOVConstruct.ma",
@@ -160,7 +160,7 @@
         "case": "MAYA_RS_AOV_012",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "AOV: Velocity"
         ],
         "scene": "AOVConstruct.ma",
@@ -176,7 +176,7 @@
         "case": "MAYA_RS_AOV_013",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "AOV: Direct Illumination"
         ],
         "scene": "AOVConstruct.ma",
@@ -191,7 +191,7 @@
         "case": "MAYA_RS_AOV_014",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "AOV: Indirect Illumination"
         ],
         "scene": "AOVConstruct.ma",
@@ -206,7 +206,7 @@
         "case": "MAYA_RS_AOV_015",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "AOV: Ambient Occlusion"
         ],
         "scene": "AOVConstruct.ma",
@@ -221,7 +221,7 @@
         "case": "MAYA_RS_AOV_016",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "AOV: Diffuse Direct"
         ],
         "scene": "AOVConstruct.ma",
@@ -236,7 +236,7 @@
         "case": "MAYA_RS_AOV_017",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "AOV: Diffuse Direct"
         ],
         "scene": "AOVConstruct.ma",
@@ -251,7 +251,7 @@
         "case": "MAYA_RS_AOV_018",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "AOV: Reflection Direct"
         ],
         "scene": "AOV_Better.ma",
@@ -266,7 +266,7 @@
         "case": "MAYA_RS_AOV_019",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "AOV: Reflection Indirect"
         ],
         "scene": "AOV_Better.ma",
@@ -281,7 +281,7 @@
         "case": "MAYA_RS_AOV_020",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "AOV: Refraction"
         ],
         "scene": "AOVConstruct.ma",
@@ -296,7 +296,7 @@
         "case": "MAYA_RS_AOV_021",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "AOV: Volume"
         ],
         "scene": "AOVConstruct.ma",
@@ -328,7 +328,7 @@
         "case": "MAYA_RS_AOV_023",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Do not compare",
             "AOV: Variance"
         ],
@@ -343,7 +343,7 @@
         "case": "MAYA_RS_AOV_024",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "AOV: Reflection Catcher"
         ],
         "scene": "AOVConstruct.ma",
@@ -358,7 +358,7 @@
         "case": "MAYA_RS_AOV_025",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "AOV: Light group 0"
         ],
         "scene": "LightGroupAOV.ma",
@@ -373,7 +373,7 @@
         "case": "MAYA_RS_AOV_026",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "AOV: Light group 1"
         ],
         "scene": "LightGroupAOV.ma",
@@ -388,7 +388,7 @@
         "case": "MAYA_RS_AOV_027",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "AOV: Light group 2"
         ],
         "scene": "LightGroupAOV.ma",
@@ -403,7 +403,7 @@
         "case": "MAYA_RS_AOV_028",
         "status": "skipped",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "AOV: Light group 3"
         ],
         "scene": "LightGroupAOV.ma",

--- a/jobs/Tests/AOV/test_cases.json
+++ b/jobs/Tests/AOV/test_cases.json
@@ -145,6 +145,7 @@
         "case": "MAYA_RS_AOV_011",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "AOV: Emission"
         ],
         "scene": "AOVConstruct.ma",
@@ -159,6 +160,7 @@
         "case": "MAYA_RS_AOV_012",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "AOV: Velocity"
         ],
         "scene": "AOVConstruct.ma",
@@ -174,6 +176,7 @@
         "case": "MAYA_RS_AOV_013",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "AOV: Direct Illumination"
         ],
         "scene": "AOVConstruct.ma",
@@ -188,6 +191,7 @@
         "case": "MAYA_RS_AOV_014",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "AOV: Indirect Illumination"
         ],
         "scene": "AOVConstruct.ma",
@@ -202,6 +206,7 @@
         "case": "MAYA_RS_AOV_015",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "AOV: Ambient Occlusion"
         ],
         "scene": "AOVConstruct.ma",
@@ -216,6 +221,7 @@
         "case": "MAYA_RS_AOV_016",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "AOV: Diffuse Direct"
         ],
         "scene": "AOVConstruct.ma",
@@ -230,6 +236,7 @@
         "case": "MAYA_RS_AOV_017",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "AOV: Diffuse Direct"
         ],
         "scene": "AOVConstruct.ma",
@@ -244,6 +251,7 @@
         "case": "MAYA_RS_AOV_018",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "AOV: Reflection Direct"
         ],
         "scene": "AOV_Better.ma",
@@ -258,6 +266,7 @@
         "case": "MAYA_RS_AOV_019",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "AOV: Reflection Indirect"
         ],
         "scene": "AOV_Better.ma",
@@ -272,6 +281,7 @@
         "case": "MAYA_RS_AOV_020",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "AOV: Refraction"
         ],
         "scene": "AOVConstruct.ma",
@@ -286,6 +296,7 @@
         "case": "MAYA_RS_AOV_021",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "AOV: Volume"
         ],
         "scene": "AOVConstruct.ma",
@@ -317,6 +328,7 @@
         "case": "MAYA_RS_AOV_023",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "Do not compare",
             "AOV: Variance"
         ],
@@ -331,6 +343,7 @@
         "case": "MAYA_RS_AOV_024",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "AOV: Reflection Catcher"
         ],
         "scene": "AOVConstruct.ma",
@@ -345,6 +358,7 @@
         "case": "MAYA_RS_AOV_025",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "AOV: Light group 0"
         ],
         "scene": "LightGroupAOV.ma",
@@ -359,6 +373,7 @@
         "case": "MAYA_RS_AOV_026",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "AOV: Light group 1"
         ],
         "scene": "LightGroupAOV.ma",
@@ -373,6 +388,7 @@
         "case": "MAYA_RS_AOV_027",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "AOV: Light group 2"
         ],
         "scene": "LightGroupAOV.ma",
@@ -387,6 +403,7 @@
         "case": "MAYA_RS_AOV_028",
         "status": "skipped",
         "script_info": [
+			"Black image expected",
             "AOV: Light group 3"
         ],
         "scene": "LightGroupAOV.ma",

--- a/jobs/Tests/AOV/test_cases.json
+++ b/jobs/Tests/AOV/test_cases.json
@@ -145,7 +145,7 @@
         "case": "MAYA_RS_AOV_011",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "AOV: Emission"
         ],
         "scene": "AOVConstruct.ma",
@@ -160,7 +160,7 @@
         "case": "MAYA_RS_AOV_012",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "AOV: Velocity"
         ],
         "scene": "AOVConstruct.ma",
@@ -176,7 +176,7 @@
         "case": "MAYA_RS_AOV_013",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "AOV: Direct Illumination"
         ],
         "scene": "AOVConstruct.ma",
@@ -191,7 +191,7 @@
         "case": "MAYA_RS_AOV_014",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "AOV: Indirect Illumination"
         ],
         "scene": "AOVConstruct.ma",
@@ -206,7 +206,7 @@
         "case": "MAYA_RS_AOV_015",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "AOV: Ambient Occlusion"
         ],
         "scene": "AOVConstruct.ma",
@@ -221,7 +221,7 @@
         "case": "MAYA_RS_AOV_016",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "AOV: Diffuse Direct"
         ],
         "scene": "AOVConstruct.ma",
@@ -236,7 +236,7 @@
         "case": "MAYA_RS_AOV_017",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "AOV: Diffuse Direct"
         ],
         "scene": "AOVConstruct.ma",
@@ -251,7 +251,7 @@
         "case": "MAYA_RS_AOV_018",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "AOV: Reflection Direct"
         ],
         "scene": "AOV_Better.ma",
@@ -266,7 +266,7 @@
         "case": "MAYA_RS_AOV_019",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "AOV: Reflection Indirect"
         ],
         "scene": "AOV_Better.ma",
@@ -281,7 +281,7 @@
         "case": "MAYA_RS_AOV_020",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "AOV: Refraction"
         ],
         "scene": "AOVConstruct.ma",
@@ -296,7 +296,7 @@
         "case": "MAYA_RS_AOV_021",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "AOV: Volume"
         ],
         "scene": "AOVConstruct.ma",
@@ -328,7 +328,7 @@
         "case": "MAYA_RS_AOV_023",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Do not compare",
             "AOV: Variance"
         ],
@@ -343,7 +343,7 @@
         "case": "MAYA_RS_AOV_024",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "AOV: Reflection Catcher"
         ],
         "scene": "AOVConstruct.ma",
@@ -358,7 +358,7 @@
         "case": "MAYA_RS_AOV_025",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "AOV: Light group 0"
         ],
         "scene": "LightGroupAOV.ma",
@@ -373,7 +373,7 @@
         "case": "MAYA_RS_AOV_026",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "AOV: Light group 1"
         ],
         "scene": "LightGroupAOV.ma",
@@ -388,7 +388,7 @@
         "case": "MAYA_RS_AOV_027",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "AOV: Light group 2"
         ],
         "scene": "LightGroupAOV.ma",
@@ -403,7 +403,7 @@
         "case": "MAYA_RS_AOV_028",
         "status": "skipped",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "AOV: Light group 3"
         ],
         "scene": "LightGroupAOV.ma",

--- a/jobs/Tests/Camera/test_cases.json
+++ b/jobs/Tests/Camera/test_cases.json
@@ -33,6 +33,7 @@
         "case": "MAYA_RS_CAM_003",
         "status": "active",
         "script_info": [
+			"Black image expected",
             "RPR Camera Type: Cubemap"
         ],
         "scene": "maya_shaderball.ma",
@@ -48,6 +49,7 @@
         "case": "MAYA_RS_CAM_004",
         "status": "active",
         "script_info": [
+			"Black image expected",
             "RPR Camera Type: Stereo cubemap"
         ],
         "scene": "maya_shaderball.ma",

--- a/jobs/Tests/Camera/test_cases.json
+++ b/jobs/Tests/Camera/test_cases.json
@@ -33,7 +33,7 @@
         "case": "MAYA_RS_CAM_003",
         "status": "active",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "RPR Camera Type: Cubemap"
         ],
         "scene": "maya_shaderball.ma",
@@ -49,7 +49,7 @@
         "case": "MAYA_RS_CAM_004",
         "status": "active",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "RPR Camera Type: Stereo cubemap"
         ],
         "scene": "maya_shaderball.ma",

--- a/jobs/Tests/Camera/test_cases.json
+++ b/jobs/Tests/Camera/test_cases.json
@@ -33,7 +33,7 @@
         "case": "MAYA_RS_CAM_003",
         "status": "active",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "RPR Camera Type: Cubemap"
         ],
         "scene": "maya_shaderball.ma",
@@ -49,7 +49,7 @@
         "case": "MAYA_RS_CAM_004",
         "status": "active",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "RPR Camera Type: Stereo cubemap"
         ],
         "scene": "maya_shaderball.ma",

--- a/jobs/Tests/IBL/test_cases.json
+++ b/jobs/Tests/IBL/test_cases.json
@@ -3,7 +3,7 @@
         "case": "MAYA_RS_IBL_001",
         "status": "active",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: Color",
             "Intensity: 0"
         ],
@@ -130,7 +130,7 @@
         "case": "MAYA_RS_IBL_008",
         "status": "active",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: IBL with hdr map",
             "Intensity: 0"
         ],
@@ -264,7 +264,7 @@
         "case": "MAYA_RS_IBL_015",
         "status": "active",
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: IBL with exr map",
             "Intensity: 0"
         ],

--- a/jobs/Tests/IBL/test_cases.json
+++ b/jobs/Tests/IBL/test_cases.json
@@ -3,6 +3,7 @@
         "case": "MAYA_RS_IBL_001",
         "status": "active",
         "script_info": [
+			"Black image expected",
             "Type: Color",
             "Intensity: 0"
         ],
@@ -129,6 +130,7 @@
         "case": "MAYA_RS_IBL_008",
         "status": "active",
         "script_info": [
+			"Black image expected",
             "Type: IBL with hdr map",
             "Intensity: 0"
         ],
@@ -262,6 +264,7 @@
         "case": "MAYA_RS_IBL_015",
         "status": "active",
         "script_info": [
+			"Black image expected",
             "Type: IBL with exr map",
             "Intensity: 0"
         ],

--- a/jobs/Tests/IBL/test_cases.json
+++ b/jobs/Tests/IBL/test_cases.json
@@ -3,7 +3,7 @@
         "case": "MAYA_RS_IBL_001",
         "status": "active",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: Color",
             "Intensity: 0"
         ],
@@ -130,7 +130,7 @@
         "case": "MAYA_RS_IBL_008",
         "status": "active",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: IBL with hdr map",
             "Intensity: 0"
         ],
@@ -264,7 +264,7 @@
         "case": "MAYA_RS_IBL_015",
         "status": "active",
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: IBL with exr map",
             "Intensity: 0"
         ],

--- a/jobs/Tests/Physical_Lights/test_cases.json
+++ b/jobs/Tests/Physical_Lights/test_cases.json
@@ -12,6 +12,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+            "Black image expected",
             "Light Type - Area",
             "Area Width - 0",
             "Intensity Units - Radience",
@@ -302,6 +303,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+            "Black image expected",
             "Light Type - Spot",
             "Light Intensity - 1",
             "Outer Cone Angle - 0"
@@ -319,6 +321,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+            "Black image expected",
             "Light Type - Spot",
             "Light Intensity - 1",
             "inner Cone Angle - 0",

--- a/jobs/Tests/Physical_Lights/test_cases.json
+++ b/jobs/Tests/Physical_Lights/test_cases.json
@@ -12,7 +12,6 @@
             "rpr_render(case)"
         ],
         "script_info": [
-            "Black image expected",
             "Light Type - Area",
             "Area Width - 0",
             "Intensity Units - Radience",

--- a/jobs/Tests/Physical_Lights/test_cases.json
+++ b/jobs/Tests/Physical_Lights/test_cases.json
@@ -12,6 +12,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+			"Black image expected",
             "Light Type - Area",
             "Area Width - 0",
             "Intensity Units - Radience",
@@ -31,6 +32,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+			"Black image expected",
             "Light Type - Area",
             "Area Width - 0",
             "Intensity Units - Mesh",
@@ -107,6 +109,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+			"Black image expected",
             "Light Type - Area",
             "Area Width - 10",
             "Area Lenght - 10",
@@ -210,6 +213,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+			"Black image expected",
             "Light Type - Area",
             "Area Lenght - 1",
             "Light Intensity - 0",
@@ -259,6 +263,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+			"Black image expected",
             "Light Type - Spot",
             "Light Intensity - 0",
             "Intensity Units - Watts",
@@ -280,6 +285,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+			"Black image expected",
             "Light Type - Spot",
             "Light Intensity - 0"
         ],
@@ -411,6 +417,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+			"Black image expected",
             "Light Type - Spot",
             "Light Intensity - 100",
             "Intensity Units - Watts",
@@ -529,6 +536,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+			"Black image expected",
             "Light Type - Spot",
             "Intensity Units Watts",
             "Color Mode - Temperature",
@@ -621,6 +629,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+			"Black image expected",
             "Light Type - Point",
             "Light Intensity - 0",
             "Intensity Units - Watts",
@@ -638,6 +647,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+			"Black image expected",
             "Light Type - Point",
             "Light Intensity - 0"
         ],
@@ -923,6 +933,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+			"Black image expected",
             "Light Type - Directional",
             "Light Intensity - 0",
             "Intensity Units - Radience",
@@ -945,6 +956,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+			"Black image expected",
             "Light Type - Directional",
             "Light Intensity - 0"
         ],

--- a/jobs/Tests/Physical_Lights/test_cases.json
+++ b/jobs/Tests/Physical_Lights/test_cases.json
@@ -12,7 +12,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Light Type - Area",
             "Area Width - 0",
             "Intensity Units - Radience",
@@ -32,7 +32,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Light Type - Area",
             "Area Width - 0",
             "Intensity Units - Mesh",
@@ -109,7 +109,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Light Type - Area",
             "Area Width - 10",
             "Area Lenght - 10",
@@ -213,7 +213,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Light Type - Area",
             "Area Lenght - 1",
             "Light Intensity - 0",
@@ -263,7 +263,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Light Type - Spot",
             "Light Intensity - 0",
             "Intensity Units - Watts",
@@ -285,7 +285,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Light Type - Spot",
             "Light Intensity - 0"
         ],
@@ -417,7 +417,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Light Type - Spot",
             "Light Intensity - 100",
             "Intensity Units - Watts",
@@ -536,7 +536,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Light Type - Spot",
             "Intensity Units Watts",
             "Color Mode - Temperature",
@@ -629,7 +629,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Light Type - Point",
             "Light Intensity - 0",
             "Intensity Units - Watts",
@@ -647,7 +647,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Light Type - Point",
             "Light Intensity - 0"
         ],
@@ -933,7 +933,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Light Type - Directional",
             "Light Intensity - 0",
             "Intensity Units - Radience",
@@ -956,7 +956,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Light Type - Directional",
             "Light Intensity - 0"
         ],

--- a/jobs/Tests/Physical_Lights/test_cases.json
+++ b/jobs/Tests/Physical_Lights/test_cases.json
@@ -12,7 +12,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Light Type - Area",
             "Area Width - 0",
             "Intensity Units - Radience",
@@ -32,7 +32,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Light Type - Area",
             "Area Width - 0",
             "Intensity Units - Mesh",
@@ -109,7 +109,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Light Type - Area",
             "Area Width - 10",
             "Area Lenght - 10",
@@ -213,7 +213,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Light Type - Area",
             "Area Lenght - 1",
             "Light Intensity - 0",
@@ -263,7 +263,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Light Type - Spot",
             "Light Intensity - 0",
             "Intensity Units - Watts",
@@ -285,7 +285,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Light Type - Spot",
             "Light Intensity - 0"
         ],
@@ -417,7 +417,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Light Type - Spot",
             "Light Intensity - 100",
             "Intensity Units - Watts",
@@ -536,7 +536,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Light Type - Spot",
             "Intensity Units Watts",
             "Color Mode - Temperature",
@@ -629,7 +629,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Light Type - Point",
             "Light Intensity - 0",
             "Intensity Units - Watts",
@@ -647,7 +647,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Light Type - Point",
             "Light Intensity - 0"
         ],
@@ -933,7 +933,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Light Type - Directional",
             "Light Intensity - 0",
             "Intensity Units - Radience",
@@ -956,7 +956,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Light Type - Directional",
             "Light Intensity - 0"
         ],

--- a/jobs/Tests/Shadow_Catcher/test_cases.json
+++ b/jobs/Tests/Shadow_Catcher/test_cases.json
@@ -42,6 +42,7 @@
             "cmds.setAttr('RadeonProRenderGlobals.aovDisplayedInRenderView', 0)"
         ],
         "script_info": [
+			"Black image expected",
             "SC AOV"
         ],
         "scene": "SC.ma"

--- a/jobs/Tests/Shadow_Catcher/test_cases.json
+++ b/jobs/Tests/Shadow_Catcher/test_cases.json
@@ -42,7 +42,7 @@
             "cmds.setAttr('RadeonProRenderGlobals.aovDisplayedInRenderView', 0)"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "SC AOV"
         ],
         "scene": "SC.ma"

--- a/jobs/Tests/Shadow_Catcher/test_cases.json
+++ b/jobs/Tests/Shadow_Catcher/test_cases.json
@@ -42,7 +42,7 @@
             "cmds.setAttr('RadeonProRenderGlobals.aovDisplayedInRenderView', 0)"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "SC AOV"
         ],
         "scene": "SC.ma"

--- a/jobs/Tests/Sun_Sky/test_cases.json
+++ b/jobs/Tests/Sun_Sky/test_cases.json
@@ -752,6 +752,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+            "Black image expected",
             "Intensity - 1",
             "Sun Position - Altitude & Azimuth",
             "Altitude - 0"
@@ -1214,6 +1215,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+            "Black image expected",
             "Intensity - 2",
             "Filter Color - sunsky_filtercolor.png",
             "Ground Color - HSV: 0, 0, 0",
@@ -1293,6 +1295,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+            "Black image expected",
             "Intensity - 2",
             "Ground Color - sunsky_groundcolor.png",
             "Sun Position - Time Location",
@@ -1349,6 +1352,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+            "Black image expected",
             "Intensity - 1",
             "Sun Position - Time Location",
             "Year - 2018",
@@ -1433,6 +1437,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+            "Black image expected",
             "Intensity - 1",
             "Sun Position - Time Location",
             "Year - 2018",
@@ -1461,6 +1466,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+            "Black image expected",
             "Intensity - 1",
             "Sun Position - Time Location",
             "Year - 2018",
@@ -1490,6 +1496,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+            "Black image expected",
             "Intensity - 1",
             "Sun Position - Time Location",
             "Year - 2018",
@@ -1550,6 +1557,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+            "Black image expected",
             "Intensity - 1",
             "Sun Position - Time Location",
             "Year - 2018",
@@ -1580,6 +1588,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+            "Black image expected",
             "Intensity - 1",
             "Sun Position - Time Location",
             "Year - 2018",
@@ -1640,6 +1649,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+            "Black image expected",
             "Intensity - 1",
             "Sun Position - Time Location",
             "Year - 2018",

--- a/jobs/Tests/Sun_Sky/test_cases.json
+++ b/jobs/Tests/Sun_Sky/test_cases.json
@@ -983,7 +983,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Intensity - 0.1",
             "Turbidity - 0",
             "Filter Color - sunsky_filtercolor.png",
@@ -1075,7 +1075,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Intensity - 0.1",
             "Turbidity - 50",
             "Filter Color - sunsky_filtercolor.tga",
@@ -1268,7 +1268,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Intensity - 0.1",
             "Filter Color - sunsky_filtercolor.png",
             "Ground Color - sunsky_groundcolor.tga",

--- a/jobs/Tests/Sun_Sky/test_cases.json
+++ b/jobs/Tests/Sun_Sky/test_cases.json
@@ -983,7 +983,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Intensity - 0.1",
             "Turbidity - 0",
             "Filter Color - sunsky_filtercolor.png",
@@ -1075,7 +1075,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Intensity - 0.1",
             "Turbidity - 50",
             "Filter Color - sunsky_filtercolor.tga",
@@ -1268,7 +1268,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Intensity - 0.1",
             "Filter Color - sunsky_filtercolor.png",
             "Ground Color - sunsky_groundcolor.tga",

--- a/jobs/Tests/Sun_Sky/test_cases.json
+++ b/jobs/Tests/Sun_Sky/test_cases.json
@@ -983,6 +983,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+			"Black image expected",
             "Intensity - 0.1",
             "Turbidity - 0",
             "Filter Color - sunsky_filtercolor.png",
@@ -1074,6 +1075,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+			"Black image expected",
             "Intensity - 0.1",
             "Turbidity - 50",
             "Filter Color - sunsky_filtercolor.tga",
@@ -1266,6 +1268,7 @@
             "rpr_render(case)"
         ],
         "script_info": [
+			"Black image expected",
             "Intensity - 0.1",
             "Filter Color - sunsky_filtercolor.png",
             "Ground Color - sunsky_groundcolor.tga",

--- a/jobs/Tests/Tone_Mapping/test_cases.json
+++ b/jobs/Tests/Tone_Mapping/test_cases.json
@@ -60,6 +60,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "0 0 +gamma"
         ],
         "scene": "maya_shaderball.ma"
@@ -106,6 +107,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "0 0 +gamma +white-balance"
         ],
         "scene": "maya_shaderball.ma"
@@ -186,6 +188,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "0 0 +gamma +white-balance=9500"
         ],
         "scene": "maya_shaderball.ma"
@@ -283,6 +286,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "Type: Linear (Scale)=0",
             "0 0 +gamma"
         ],
@@ -338,6 +342,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "Type: Linear (Scale)=0",
             "0 0 +gamma +white-balance"
         ],
@@ -429,6 +434,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "Type: Linear (Scale)=0",
             "0 0 +gamma +white-balance=9500"
         ],
@@ -535,6 +541,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "Type: Photolinear (0 0 0)",
             "0 0 +gamma"
         ],
@@ -596,6 +603,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "Type: PhotoLinear (0 0 0)",
             "0 0 +gamma +white-balance"
         ],
@@ -693,6 +701,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "Type: PhotoLinear (0 0 0)",
             "0 0 +gamma +white-balance=9500"
         ],
@@ -800,6 +809,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "Type: Autolinear 0 0 +gamma"
         ],
         "scene": "maya_shaderball.ma"
@@ -849,6 +859,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "Type: Autolinear 0 0 +gamma +white-balance"
         ],
         "scene": "maya_shaderball.ma"
@@ -933,6 +944,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "Type: Autolinear 0 0 +gamma +white-balance=9500"
         ],
         "scene": "maya_shaderball.ma"
@@ -1031,6 +1043,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "Type: MaxWhite 0 0 +gamma"
         ],
         "scene": "maya_shaderball.ma"
@@ -1080,6 +1093,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "Type: MaxWhite 0 0 +gamma +white-balance"
         ],
         "scene": "maya_shaderball.ma"
@@ -1165,6 +1179,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "Type: MaxWhite 0 0 +gamma +white-balance=9500"
         ],
         "scene": "maya_shaderball.ma"
@@ -1266,6 +1281,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "Type: Reinhard02 (0 0 0)",
             "0 0 +gamma"
         ],
@@ -1326,6 +1342,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "Type: Reinhard02 (0 0 0)",
             "0 0 +gamma +white-balance"
         ],
@@ -1422,6 +1439,7 @@
             "resetAttributes()"
         ],
         "script_info": [
+			"Black image expected",
             "Type: Reinhard02 (0 0 0)",
             "0 0 +gamma +white-balance=9500"
         ],

--- a/jobs/Tests/Tone_Mapping/test_cases.json
+++ b/jobs/Tests/Tone_Mapping/test_cases.json
@@ -60,7 +60,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "0 0 +gamma"
         ],
         "scene": "maya_shaderball.ma"
@@ -107,7 +107,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "0 0 +gamma +white-balance"
         ],
         "scene": "maya_shaderball.ma"
@@ -188,7 +188,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "0 0 +gamma +white-balance=9500"
         ],
         "scene": "maya_shaderball.ma"
@@ -286,7 +286,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: Linear (Scale)=0",
             "0 0 +gamma"
         ],
@@ -342,7 +342,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: Linear (Scale)=0",
             "0 0 +gamma +white-balance"
         ],
@@ -434,7 +434,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: Linear (Scale)=0",
             "0 0 +gamma +white-balance=9500"
         ],
@@ -541,7 +541,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: Photolinear (0 0 0)",
             "0 0 +gamma"
         ],
@@ -603,7 +603,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: PhotoLinear (0 0 0)",
             "0 0 +gamma +white-balance"
         ],
@@ -701,7 +701,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: PhotoLinear (0 0 0)",
             "0 0 +gamma +white-balance=9500"
         ],
@@ -809,7 +809,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: Autolinear 0 0 +gamma"
         ],
         "scene": "maya_shaderball.ma"
@@ -859,7 +859,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: Autolinear 0 0 +gamma +white-balance"
         ],
         "scene": "maya_shaderball.ma"
@@ -944,7 +944,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: Autolinear 0 0 +gamma +white-balance=9500"
         ],
         "scene": "maya_shaderball.ma"
@@ -1043,7 +1043,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: MaxWhite 0 0 +gamma"
         ],
         "scene": "maya_shaderball.ma"
@@ -1093,7 +1093,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: MaxWhite 0 0 +gamma +white-balance"
         ],
         "scene": "maya_shaderball.ma"
@@ -1179,7 +1179,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: MaxWhite 0 0 +gamma +white-balance=9500"
         ],
         "scene": "maya_shaderball.ma"
@@ -1281,7 +1281,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: Reinhard02 (0 0 0)",
             "0 0 +gamma"
         ],
@@ -1342,7 +1342,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: Reinhard02 (0 0 0)",
             "0 0 +gamma +white-balance"
         ],
@@ -1439,7 +1439,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-		"Black image expected",
+            "Black image expected",
             "Type: Reinhard02 (0 0 0)",
             "0 0 +gamma +white-balance=9500"
         ],

--- a/jobs/Tests/Tone_Mapping/test_cases.json
+++ b/jobs/Tests/Tone_Mapping/test_cases.json
@@ -60,7 +60,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "0 0 +gamma"
         ],
         "scene": "maya_shaderball.ma"
@@ -107,7 +107,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "0 0 +gamma +white-balance"
         ],
         "scene": "maya_shaderball.ma"
@@ -188,7 +188,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "0 0 +gamma +white-balance=9500"
         ],
         "scene": "maya_shaderball.ma"
@@ -286,7 +286,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: Linear (Scale)=0",
             "0 0 +gamma"
         ],
@@ -342,7 +342,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: Linear (Scale)=0",
             "0 0 +gamma +white-balance"
         ],
@@ -434,7 +434,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: Linear (Scale)=0",
             "0 0 +gamma +white-balance=9500"
         ],
@@ -541,7 +541,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: Photolinear (0 0 0)",
             "0 0 +gamma"
         ],
@@ -603,7 +603,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: PhotoLinear (0 0 0)",
             "0 0 +gamma +white-balance"
         ],
@@ -701,7 +701,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: PhotoLinear (0 0 0)",
             "0 0 +gamma +white-balance=9500"
         ],
@@ -809,7 +809,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: Autolinear 0 0 +gamma"
         ],
         "scene": "maya_shaderball.ma"
@@ -859,7 +859,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: Autolinear 0 0 +gamma +white-balance"
         ],
         "scene": "maya_shaderball.ma"
@@ -944,7 +944,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: Autolinear 0 0 +gamma +white-balance=9500"
         ],
         "scene": "maya_shaderball.ma"
@@ -1043,7 +1043,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: MaxWhite 0 0 +gamma"
         ],
         "scene": "maya_shaderball.ma"
@@ -1093,7 +1093,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: MaxWhite 0 0 +gamma +white-balance"
         ],
         "scene": "maya_shaderball.ma"
@@ -1179,7 +1179,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: MaxWhite 0 0 +gamma +white-balance=9500"
         ],
         "scene": "maya_shaderball.ma"
@@ -1281,7 +1281,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: Reinhard02 (0 0 0)",
             "0 0 +gamma"
         ],
@@ -1342,7 +1342,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: Reinhard02 (0 0 0)",
             "0 0 +gamma +white-balance"
         ],
@@ -1439,7 +1439,7 @@
             "resetAttributes()"
         ],
         "script_info": [
-			"Black image expected",
+		"Black image expected",
             "Type: Reinhard02 (0 0 0)",
             "0 0 +gamma +white-balance=9500"
         ],


### PR DESCRIPTION
- TRELLO TICKET
https://trello.com/c/wI7AmJV9/140-marking-expected-black-images

- PURPOSE
To mark all expected black images for RPRMayaPlugin

- REPORTS
https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderMayaPluginManual/3824/

- NOTES FOR REVIEWERS
All expected black images were marked after reviewing report