### PR TITLE
Marked black image expected after weekly builds

### DIFF
--- a/jobs/Tests/Adaptive_Sampling/test_cases.json
+++ b/jobs/Tests/Adaptive_Sampling/test_cases.json
@@ -789,6 +789,7 @@
         "case": "MAYA_RS_AS_031",
         "status": "active",
         "script_info": [
+            "Black image expected",
             "Min iteration- 20",
             "Max Iterations - 1000",
             "Max Time Minutes - 1",
@@ -858,6 +859,7 @@
         "case": "MAYA_RS_AS_033",
         "status": "active",
         "script_info": [
+            "Black image expected",
             "Min iteration- 20",
             "Max Iterations - 1000",
             "Max Time Minutes - 1",

--- a/jobs/Tests/Base_Lights/test_cases.json
+++ b/jobs/Tests/Base_Lights/test_cases.json
@@ -375,6 +375,7 @@
         "case": "MAYA_L_BL_020",
         "status": "active",
         "script_info": [
+            "Black image expected",
             "Spot light. Intensity: 40"
         ],
         "scene": "maya_shaderball.ma",


### PR DESCRIPTION
PURPOSE
To mark all expected black images after weekly build

REPORTS
https://rpr.cis.luxoft.com/job/RadeonProRenderMayaPlugin-WeeklyFullNorthstar/14/Test_20Report/
https://rpr.cis.luxoft.com/job/RadeonProRenderMayaPlugin-WeeklyFull/307/Test_20Report/