### PR TITLE
Build jsons for skipped cases before running tests

### DIFF
--- a/jobs/Scripts/base_functions.py
+++ b/jobs/Scripts/base_functions.py
@@ -49,16 +49,11 @@ def reportToJSON(case, render_time=0):
 
     logging('Create report json ({{}} {{}})'.format(
             case['case'], report['test_status']))
-
-    if case['status'] == 'skipped':
-        report['file_name'] = case['case'] + '.jpg'
-    else:
-        report['file_name'] = case['case'] + case.get('extension', '.jpg')
+  
     report['tool'] = mel.eval('about -iv')
     report['date_time'] = datetime.datetime.now().strftime('%m/%d/%Y %H:%M:%S')
     report['render_version'] = mel.eval('getRPRPluginVersion()')
     report['core_version'] = mel.eval('getRprCoreVersion()')
-    report['render_color_path'] = path.join('Color', report['file_name'])
     report['render_time'] = render_time
     report['test_group'] = TEST_TYPE
     report['test_case'] = case['case']
@@ -66,6 +61,9 @@ def reportToJSON(case, render_time=0):
     report['script_info'] = case['script_info']
     report['render_log'] = path.join('render_tool_logs', case['case'] + '.log')
     report['scene_name'] = case.get('scene', '')
+    if case['status'] != 'skipped':
+        report['file_name'] = case['case'] + case.get('extension', '.jpg')
+        report['render_color_path'] = path.join('Color', report['file_name'])
     with open(path_to_file, 'w') as file:
         file.write(json.dumps([report], indent=4))
 
@@ -185,7 +183,7 @@ def save_report(case):
 
     if case['status'] == 'inprogress':
         copyfile(path.join(source_dir, 'passed.jpg'), work_dir)
-    else:
+    elif case['status'] != 'skipped':
         copyfile(
             path.join(source_dir, case['status'] + '.jpg'), work_dir)
 

--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -355,7 +355,7 @@ def main(args, error_windows):
                 template['group_timeout_exceeded'] = False
 
                 try:
-                    skipped_case_image_path = os.path.join(args.output, 'Color', report['file_name'])
+                    skipped_case_image_path = os.path.join(args.output, 'Color', template['file_name'])
                     if not os.path.exists(skipped_case_image_path):
                         copyfile(os.path.join(work_dir, '..', '..', '..', '..', 'jobs_launcher', 
                             'common', 'img', "skipped.png"), skipped_case_image_path)

--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -343,16 +343,28 @@ def main(args, error_windows):
             template = core_config.RENDER_REPORT_BASE.copy()
             template['test_case'] = case['case']
             template['render_device'] = get_gpu()
-            template['test_status'] = 'error'
             template['script_info'] = case['script_info']
             template['scene_name'] = case.get('scene', '')
-            template['file_name'] = 'failed.jpg'
-            template['render_color_path'] = os.path.join('Color', 'failed.jpg')
             template['test_group'] = args.testType
             template['date_time'] = datetime.now().strftime(
                 '%m/%d/%Y %H:%M:%S')
             if case['status'] == 'skipped':
+                template['test_status'] = 'skipped'
+                template['file_name'] = case['case'] + case.get('extension', '.jpg')
+                template['render_color_path'] = os.path.join('Color', template['file_name'])
                 template['group_timeout_exceeded'] = False
+
+                try:
+                    skipped_case_image_path = os.path.join(args.output, 'Color', report['file_name'])
+                    if not os.path.exists(skipped_case_image_path):
+                        copyfile(os.path.join(work_dir, '..', '..', '..', '..', 'jobs_launcher', 
+                            'common', 'img', "skipped.png"), skipped_case_image_path)
+                except OSError or FileNotFoundError as err:
+                    main_logger.error("Can't create img stub: {}".format(str(err)))
+            else:
+                template['test_status'] = 'error'
+                template['file_name'] = 'failed.jpg'
+                template['render_color_path'] = os.path.join('Color', 'failed.jpg')
 
             with open(os.path.join(work_dir, case['case'] + core_config.CASE_REPORT_SUFFIX), 'w') as f:
                 f.write(json.dumps([template], indent=4))


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1793
### Purpose
* Build jsons for skipped cases before running tests (it's necessary for send data in progress_monitor + it allows to prevent unexpected error test cases instead of skipped cases)
### :octocat: Related PR'S
* jobs_test_blender: https://github.com/luxteam/jobs_test_blender/pull/155
### Jenkins Builds
* Blender: https://rpr.cis.luxoft.com/job/DevRadeonProRenderMayaPluginManual/47/
* https://rpr.cis.luxoft.com/job/DevRadeonProRenderMayaPluginManual/50/