### PR TITLE
Rework adding of error messages in simpleRender and base_function scripts

### DIFF
--- a/jobs/Scripts/base_functions.py
+++ b/jobs/Scripts/base_functions.py
@@ -50,10 +50,7 @@ def reportToJSON(case, render_time=0):
     logging('Create report json ({{}} {{}})'.format(
             case['case'], report['test_status']))
   
-    report['tool'] = mel.eval('about -iv')
     report['date_time'] = datetime.datetime.now().strftime('%m/%d/%Y %H:%M:%S')
-    report['render_version'] = mel.eval('getRPRPluginVersion()')
-    report['core_version'] = mel.eval('getRprCoreVersion()')
     report['render_time'] = render_time
     report['test_group'] = TEST_TYPE
     report['test_case'] = case['case']
@@ -64,6 +61,25 @@ def reportToJSON(case, render_time=0):
     if case['status'] != 'skipped':
         report['file_name'] = case['case'] + case.get('extension', '.jpg')
         report['render_color_path'] = path.join('Color', report['file_name'])
+
+    # save metrics which can be received witout call of functions of Maya
+    with open(path_to_file, 'w') as file:
+        file.write(json.dumps([report], indent=4))
+
+    try:
+        report['tool'] = mel.eval('about -iv')
+    except Exception as e:
+        logging('Failed to get Maya version. Reason: {{}}'.format(str(e)))
+    try:
+        report['render_version'] = mel.eval('getRPRPluginVersion()')
+    except Exception as e:
+        logging('Failed to get render version. Reason: {{}}'.format(str(e)))
+    try:
+        report['core_version'] = mel.eval('getRprCoreVersion()')
+    except Exception as e:
+        logging('Failed to get core version. Reason: {{}}'.format(str(e)))
+
+    # save metrics which can't be received witout call of functions of Maya (additional measures to avoid stucking of Maya)
     with open(path_to_file, 'w') as file:
         file.write(json.dumps([report], indent=4))
 

--- a/jobs/Scripts/base_functions.py
+++ b/jobs/Scripts/base_functions.py
@@ -50,11 +50,16 @@ def reportToJSON(case, render_time=0):
     logging('Create report json ({{}} {{}})'.format(
             case['case'], report['test_status']))
 
-    number_of_tries = case.get('number_of_tries', 0)
     if case['status'] == 'error':
-        error_message = 'Testcase wasn\'t executed successfully (all attempts were used). Number of tries: {{}}'.format(str(number_of_tries))
-        report['message'].append(error_message)
-  
+        number_of_tries = case.get('number_of_tries', 0)
+        if number_of_tries == RETRIES
+            error_message = 'Testcase wasn\'t executed successfully (all attempts were used). Number of tries: {{}}'.format(str(number_of_tries))
+        else:
+            error_message = 'Testcase wasn\'t executed successfully. Number of tries: {{}}'.format(str(number_of_tries))
+        report['message'] = [error_message]
+    else:
+        report['message'] = []
+
     report['date_time'] = datetime.datetime.now().strftime('%m/%d/%Y %H:%M:%S')
     report['render_time'] = render_time
     report['test_group'] = TEST_TYPE

--- a/jobs/Scripts/base_functions.py
+++ b/jobs/Scripts/base_functions.py
@@ -49,6 +49,11 @@ def reportToJSON(case, render_time=0):
 
     logging('Create report json ({{}} {{}})'.format(
             case['case'], report['test_status']))
+
+    number_of_tries = case.get('number_of_tries', 0)
+    if case['status'] == 'error':
+        error_message = 'Testcase wasn\'t executed successfully (all attempts were used). Number of tries: {{}}'.format(str(number_of_tries))
+        report['message'].append(error_message)
   
     report['date_time'] = datetime.datetime.now().strftime('%m/%d/%Y %H:%M:%S')
     report['render_time'] = render_time

--- a/jobs/Scripts/base_functions.py
+++ b/jobs/Scripts/base_functions.py
@@ -52,7 +52,7 @@ def reportToJSON(case, render_time=0):
 
     if case['status'] == 'error':
         number_of_tries = case.get('number_of_tries', 0)
-        if number_of_tries == RETRIES
+        if number_of_tries == RETRIES:
             error_message = 'Testcase wasn\'t executed successfully (all attempts were used). Number of tries: {{}}'.format(str(number_of_tries))
         else:
             error_message = 'Testcase wasn\'t executed successfully. Number of tries: {{}}'.format(str(number_of_tries))

--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -553,16 +553,15 @@ if __name__ == '__main__':
                 last_error_case = case
 
         if last_error_case and error_windows:
+            path_to_file = os.path.join(args.output, last_error_case['case'] + '_RPR.json')
+            with open(path_to_file, 'r') as file:
+                report = json.load(file)
+
             number_of_tries = last_error_case.get('number_of_tries', 1)
-            if number_of_tries == args.retries:
-                path_to_file = os.path.join(args.output, last_error_case['case'] + '_RPR.json')
-                with open(path_to_file, 'r') as file:
-                    report = json.load(file)
+            report[0]['message'].append("Error windows {} (try #{})".format(error_windows, number_of_tries))
 
-                report[0]['message'].append("Error windows: {}".format(error_windows))
-
-                with open(path_to_file, 'w') as file:
-                    json.dump(report, file, indent=4)
+            with open(path_to_file, 'w') as file:
+                json.dump(report, file, indent=4)
 
         if active_cases == 0 or iteration > len(cases) * args.retries:
             # exit script if base_functions don't change number of active cases

--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -557,8 +557,7 @@ if __name__ == '__main__':
             with open(path_to_file, 'r') as file:
                 report = json.load(file)
 
-            number_of_tries = last_error_case.get('number_of_tries', 1)
-            report[0]['message'].append("Error windows {} (try #{})".format(error_windows, number_of_tries))
+            report[0]['message'].append("Error windows {}".format(error_windows))
 
             with open(path_to_file, 'w') as file:
                 json.dump(report, file, indent=4)

--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -507,10 +507,11 @@ if __name__ == '__main__':
         core_config.main_logger.error(str(e))
         exit(-1)
 
-    error_windows = set()
 
     while True:
         iteration += 1
+
+        error_windows = set()
 
         core_config.main_logger.info(
             'Try to run script in maya (#' + str(iteration) + ')')
@@ -534,6 +535,7 @@ if __name__ == '__main__':
         active_cases = 0
         current_error_count = 0
 
+        last_error_case = None
         for case in cases:
             if case['status'] in ['fail', 'error', 'inprogress']:
                 current_error_count += 1
@@ -545,33 +547,24 @@ if __name__ == '__main__':
             if case['status'] in ['active', 'fail', 'inprogress']:
                 active_cases += 1
 
+            path_to_file = os.path.join(args.output, case['case'] + '_RPR.json')
+
+            if case['status'] == 'error':
+                last_error_case = case
+
+        if last_error_case and error_windows:
+            number_of_tries = last_error_case.get('number_of_tries', 1)
+            if number_of_tries == args.retries:
+                path_to_file = os.path.join(args.output, last_error_case['case'] + '_RPR.json')
+                with open(path_to_file, 'r') as file:
+                    report = json.load(file)
+
+                report[0]['message'].append("Error windows: {}".format(error_windows))
+
+                with open(path_to_file, 'w') as file:
+                    json.dump(report, file, indent=4)
+
         if active_cases == 0 or iteration > len(cases) * args.retries:
-            for case in cases:
-                error_message = ''
-                number_of_tries = case.get('number_of_tries', 0)
-                if case['status'] in ['fail', 'error']:
-                    error_message = "Testcase wasn't executed successfully (all attempts were used). Number of tries: {}".format(str(number_of_tries))
-                elif case['status'] in ['active', 'inprogress']:
-                    if number_of_tries:
-                        error_message = "Testcase wasn't finished. Number of tries: {}".format(str(number_of_tries))
-                    else:
-                        error_message = "Testcase wasn't run"
-
-                if error_message:
-                    core_config.main_logger.info("Testcase {} wasn't finished successfully: {}".format(case['case'], error_message))
-                    path_to_file = os.path.join(args.output, case['case'] + '_RPR.json')
-
-                    with open(path_to_file, 'r') as file:
-                        report = json.load(file)
-
-                    report[0]['group_timeout_exceeded'] = False
-                    report[0]['message'].append(error_message)
-                    if len(error_windows) != 0:
-                        report[0]['message'].append("Error windows {}".format(error_windows))
-
-                    with open(path_to_file, 'w') as file:
-                        json.dump(report, file, indent=4)
-
             # exit script if base_functions don't change number of active cases
             kill_process(PROCESS)
             core_config.main_logger.info(


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1789
* https://adc.luxoft.com/jira/browse/STVCIS-1882
### Purpose
* Rework adding of error messages in simpleRender and base_function scripts
### Effect of changes
* If group fails due to timeout, cases which weren't rendered on each attemps have correct error messages.
### :octocat: Related PR'S
* jobs_test_blender: https://github.com/luxteam/jobs_test_blender/pull/172
### Jenkins Builds
* Common build: https://rpr.cis.luxoft.com/job/DevRadeonProRenderMayaPluginManual/73/
* Reproduce errors: https://rpr.cis.luxoft.com/job/DevRadeonProRenderMayaPluginManual/72/