### PR TITLE
Fix restarting of Maya each <timeout_value> on OSX

### DIFF
--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -44,7 +44,7 @@ def get_windows_titles():
                            for x in windows_list if 'Maya' in x['kCGWindowOwnerName']}
 
             # duct tape for windows with empty title
-            expected = {'Maya', 'Render View', 'Rendering...'}
+            expected = {'Maya', 'Render View', 'Rendering...', 'Unknown'}
             if maya_titles - expected:
                 maya_titles.add('Detected windows ERROR')
 

--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -32,11 +32,20 @@ if platform.system() == 'Darwin':
     from Quartz import kCGWindowListOptionOnScreenOnly
     from Quartz import kCGNullWindowID
     from Quartz import kCGWindowName
+    from Quartz import CGWindowListCreateImage
+    from Quartz import CGRectMake
+    from Quartz import kCGWindowImageDefault
 
 
 def get_windows_titles():
     try:
         if platform.system() == 'Darwin':
+            CGWindowListCreateImage(
+                CGRectMake(0, 0, 1, 1),
+                kCGWindowListOptionOnScreenOnly,
+                kCGNullWindowID,
+                kCGWindowImageDefault
+            )
             ws_options = kCGWindowListOptionOnScreenOnly
             windows_list = CGWindowListCopyWindowInfo(
                 ws_options, kCGNullWindowID)
@@ -44,7 +53,7 @@ def get_windows_titles():
                            for x in windows_list if 'Maya' in x['kCGWindowOwnerName']}
 
             # duct tape for windows with empty title
-            expected = {'Maya', 'Render View', 'Rendering...', 'Unknown'}
+            expected = {'Maya', 'Render View', 'Rendering...'}
             if maya_titles - expected:
                 maya_titles.add('Detected windows ERROR')
 

--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -40,6 +40,7 @@ if platform.system() == 'Darwin':
 def get_windows_titles():
     try:
         if platform.system() == 'Darwin':
+            # for receive kCGWindowName values from CGWindowListCopyWindowInfo function it's necessary to call any function of Screen Record API
             CGWindowListCreateImage(
                 CGRectMake(0, 0, 1, 1),
                 kCGWindowListOptionOnScreenOnly,


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1711
### Purpose
* Fix restarting of Maya each <timeout_value>
### Effect of changes
* Fix detecting of error windows on OSX (Call Screen Record API function (make a screenshot) for allow CGWindowListCopyWindowInfo to get names of windows)
### Jenkins build
* https://rpr.cis.luxoft.com/job/RadeonProRenderMayaPluginManual/4064/