### PR TITLE
Akulbako/matlib checking

### DIFF
--- a/scripts/build_rpr_cache.bat
+++ b/scripts/build_rpr_cache.bat
@@ -5,4 +5,4 @@ set MAYA_CMD_FILE_OUTPUT=%CD%\..\Work\Results\Maya
 set TOOL=%1
 if not defined TOOL set TOOL=2020
 
-"C:\\Program Files\\Autodesk\\Maya%TOOL%\\bin\\Render.exe" -r FireRender -log "%MAYA_CMD_FILE_OUTPUT%\renderTool.cb.log" -rd "%MAYA_CMD_FILE_OUTPUT%" -im "cache_building" -of jpg "C:\\TestResources\\MayaAssets\\cache.mb"
+"C:\\Program Files\\Autodesk\\Maya%TOOL%\\bin\\Render.exe" -r FireRender -log "%MAYA_CMD_FILE_OUTPUT%\renderTool.cb.log" -rd "%MAYA_CMD_FILE_OUTPUT%" -im "cache_building" -of jpg "C:\\TestResources\\MayaAssets\\material_baseline.mb"

--- a/scripts/build_rpr_cache.sh
+++ b/scripts/build_rpr_cache.sh
@@ -5,4 +5,4 @@ export MAYA_CMD_FILE_OUTPUT=$PWD/../Work/Results/Maya
 
 TOOL=${1:-2020}
 
-/Applications/Autodesk/Maya${TOOL}/Maya.app/Contents/bin/Render -r FireRender -log "$MAYA_CMD_FILE_OUTPUT/renderTool.cb.log" -rd "$MAYA_CMD_FILE_OUTPUT" -im "cache_building" -of jpg "$CIS_TOOLS/../TestResources/MayaAssets/cache.mb"
+/Applications/Autodesk/Maya${TOOL}/Maya.app/Contents/bin/Render -r FireRender -log "$MAYA_CMD_FILE_OUTPUT/renderTool.cb.log" -rd "$MAYA_CMD_FILE_OUTPUT" -im "cache_building" -of jpg "$CIS_TOOLS/../TestResources/MayaAssets/material_baseline.mb"


### PR DESCRIPTION
### Jira Ticket
- https://adc.luxoft.com/jira/secure/RapidBoard.jspa?rapidView=1577&projectKey=STVCIS&view=planning&selectedIssue=STVCIS-1979

### Purpose
- Checking whether the material library has been installed on a node

### Effect of change
- Checks the presence of the material on the scene, if it is absent, installs the library. Checks the fact of installation through the registry on windows systems.

### Technical steps
- [x] Creates test scene with link to material from AMD library
- [x] Call matlib script
- [x] Check registry key on Windows

### :octocat: Related PR'S
- https://github.com/luxteam/jobs_test_blender/pull/181
- https://github.com/luxteam/jobs_test_maya/pull/260
- https://github.com/luxteam/rpr_pipelines/pull/405
- https://github.com/luxteam/jobs_launcher/pull/143

### Jenkins Builds
- Without matlib: https://rpr.cis.luxoft.com/job/RadeonProRenderMayaPluginManual/4299/
- With matlib: https://rpr.cis.luxoft.com/job/RadeonProRenderMayaPluginManual/4302/