### PR TITLE
Actualize setup time steps in Maya autotests

### DIFF
--- a/jobs/Scripts/refactor_logs.py
+++ b/jobs/Scripts/refactor_logs.py
@@ -78,6 +78,7 @@ Case\t\tStatus\tTime\tTries
 
 
 def performance_count(work_dir):
+    end_of_script_events = ['Sync time count', 'Make report json']
     old_event = {'name': 'init', 'time': '', 'start': True}
     time_diffs = []
     time_diffs_summary = []
@@ -94,8 +95,8 @@ def performance_count(work_dir):
             if ((old_event['name'] == event['name'] and old_event['start'] and not event['start']) or
                 # or new event was started without finishing of previous one (e.g. timeouts)
                 (old_event['name'] != event['name'] and old_event['start'] and event['start']) or
-                # or there is delay between different events (e.g. start of new script execution; exclude render)
-                (old_event['name'] != event['name'] and old_event['name'] != 'Prerender' and not old_event['start'] and event['start'])):
+                # or new script started
+                (old_event['name'] != event['name'] and old_event['name'] in end_of_script_events and not old_event['start'] and event['start'])):
 
                 if old_event['name'] == event['name']:
                     event_name = event['name']

--- a/jobs/Scripts/refactor_logs.py
+++ b/jobs/Scripts/refactor_logs.py
@@ -95,8 +95,7 @@ def performance_count(work_dir):
                 # or new event was started without finishing of previous one (e.g. timeouts)
                 (old_event['name'] != event['name'] and old_event['start'] and event['start']) or
                 # or there is delay between different events (e.g. start of new script execution; exclude render)
-                (old_event['name'] != event['name'] and old_event['name'] != 'Prerender' and not old_event['start'] 
-                    and event['name'] != 'Postrender' and event['start'])):
+                (old_event['name'] != event['name'] and old_event['name'] != 'Prerender' and not old_event['start'] and event['start'])):
 
                 if old_event['name'] == event['name']:
                     event_name = event['name']

--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -487,6 +487,7 @@ def group_failed(args, error_windows):
     exit(rc)
 
 def sync_time(work_dir):
+    perf_count.event_record(directory, 'Sync time count', True)
     for rpr_json_path in os.listdir(work_dir):
         if rpr_json_path.endswith('_RPR.json'):
             try:
@@ -516,6 +517,7 @@ def sync_time(work_dir):
                     rpr_json_file.write(json.dumps(rpr_json, indent=4))
             except:
                 core_config.main_logger.error("Can't count sync time for " + rpr_json_path)
+    perf_count.event_record(directory, 'Sync time count', False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-2058
### Purpose
* Actualize setup time steps in Maya autotests
### Effect of change
* Actualize setup time steps in Maya autotests
* Fix issue with ignored waiting between launching of scripts
* Fix calculation of time for unfinished events
### :octocat: Related PR'S
* jobs_test_blender: https://github.com/luxteam/jobs_test_blender/pull/200
### Jenkins Builds
* https://rpr.cis.luxoft.com/job/RadeonProRenderMayaPluginManual/4418/