### PR TITLE
Fix saving of message about error windows

### DIFF
--- a/jobs/Scripts/base_functions.py
+++ b/jobs/Scripts/base_functions.py
@@ -54,11 +54,15 @@ def reportToJSON(case, render_time=0):
 
     number_of_tries = case.get('number_of_tries', 0)
     if case['status'] == 'error':
+        # remove old message
+        for message in report['message']:
+            if 'Testcase wasn\'t executed successfully' in message:
+                report['message'].remove(message)
         if number_of_tries == RETRIES:
             error_message = 'Testcase wasn\'t executed successfully (all attempts were used)'
         else:
             error_message = 'Testcase wasn\'t executed successfully'
-        report['message'] = [error_message]
+        report['message'].append(error_message)
         report['group_timeout_exceeded'] = False
     else:
         report['message'] = []

--- a/jobs/Scripts/simpleRender.py
+++ b/jobs/Scripts/simpleRender.py
@@ -389,6 +389,7 @@ def main(args, error_windows):
                     case_json = json.load(f)[0]
                     template["error_screen_path"] = case_json["error_screen_path"]
                     template["number_of_tries"] = case_json["number_of_tries"]
+                    template["message"] = case_json["message"]
 
             with open(case_path, 'w') as f:
                 f.write(json.dumps([template], indent=4))
@@ -585,7 +586,7 @@ if __name__ == '__main__':
 
             path_to_file = os.path.join(args.output, case['case'] + '_RPR.json')
 
-            if case['status'] == 'error':
+            if case['status'] == 'inprogress':
                 last_error_case = case
 
         if last_error_case and error_windows:
@@ -593,7 +594,9 @@ if __name__ == '__main__':
             with open(path_to_file, 'r') as file:
                 report = json.load(file)
 
-            report[0]['message'].append("Error windows {}".format(error_windows))
+            error_windows_message = 'Error windows {}'.format(error_windows)
+            if error_windows_message not in report[0]['message']:
+                report[0]['message'].append(error_windows_message)
 
             with open(path_to_file, 'w') as file:
                 json.dump(report, file, indent=4)


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-2080
### Purpose
* Fix saving of message about error windows
### Effect of change
* Write error window message to the last "inprogress" case, not to the last "error" case
### Jenkins Builds
* Common build: https://rpr.cis.luxoft.com/job/RadeonProRenderMayaPluginManual/4461/
* Error window: https://rpr.cis.luxoft.com/job/RadeonProRenderMayaPluginManual/4460/