### PR TITLE
cpu/dual 018 case skipped

### DIFF
--- a/jobs/Tests/CPU_Mode/test_cases.json
+++ b/jobs/Tests/CPU_Mode/test_cases.json
@@ -251,7 +251,7 @@
         ],
         "script_info": [
             "Complex 2",
-            "Random artefacts"
+            "https://amdrender.atlassian.net/browse/RPRMAYA-2663"
         ],
         "scene": "CorvetteRPR.ma"
     },

--- a/jobs/Tests/CPU_Mode/test_cases.json
+++ b/jobs/Tests/CPU_Mode/test_cases.json
@@ -245,12 +245,13 @@
     },
     {
         "case": "MAYA_RS_CPU_018",
-        "status": "active",
+        "status": "skipped",
         "functions": [
             "rpr_render(case)"
         ],
         "script_info": [
-            "Complex 2"
+            "Complex 2",
+            "Random artefacts"
         ],
         "scene": "CorvetteRPR.ma"
     },

--- a/jobs/Tests/Dual_Mode/test_cases.json
+++ b/jobs/Tests/Dual_Mode/test_cases.json
@@ -299,8 +299,7 @@
         ],
         "script_info": [
             "Complex 2",
-            "https://amdrender.atlassian.net/browse/RPRMAYA-2660",
-            "Random artefacts"
+            "https://amdrender.atlassian.net/browse/RPRMAYA-2663"
         ],
         "scene": "CorvetteRPR.ma",
         "skip_config": [

--- a/jobs/Tests/Dual_Mode/test_cases.json
+++ b/jobs/Tests/Dual_Mode/test_cases.json
@@ -293,13 +293,14 @@
     },
     {
         "case": "MAYA_RS_DUAL_018",
-        "status": "active",
+        "status": "skipped",
         "functions": [
             "rpr_render(case)"
         ],
         "script_info": [
             "Complex 2",
-            "https://amdrender.atlassian.net/browse/RPRMAYA-2660"
+            "https://amdrender.atlassian.net/browse/RPRMAYA-2660",
+            "Random artefacts"
         ],
         "scene": "CorvetteRPR.ma",
         "skip_config": [


### PR DESCRIPTION
Purpose

- To skip broken case from cpu/dual groups

Jenlins Build

- https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderMayaPlugin-WeeklyFullNorthstar/39/Test_20Report/Northstar/AMD_RX5700XT-Windows-CPU_Mode%20Render_Layer/Results/Maya/CPU_Mode/report.html?searchText=MAYA_RS_CPU_018

Jira Tecket

- https://amdrender.atlassian.net/browse/RPRMAYA-2663