### PR TITLE
complex 009 case skipped on tahoe

### DIFF
--- a/jobs/Tests/Complex/test_cases.json
+++ b/jobs/Tests/Complex/test_cases.json
@@ -96,6 +96,9 @@
         "scene": "RPR_LightComplexity_Pointlights.ma",
         "functions": [
             "rpr_render(case)"
+        ],
+        "skip_engine": [
+            "Tahoe"
         ]
     },
     {


### PR DESCRIPTION
Purpose

- Skip problem case in Complex group on Tahoe

Jenkins Build

- https://rpr.cis.luxoft.com/view/RPR%20Plugins/job/RadeonProRenderMayaPluginAuto/job/develop/181/Test_20Report/Tahoe/AMD_RX6800-Windows-regression.json~/Results/Maya/Complex/report.html?searchText=MAYA_RS_CMX_009

Jira Ticket

- https://amdrender.atlassian.net/browse/RPRMAYA-2711